### PR TITLE
Fix w.pop not working on nests added with w.add on a function

### DIFF
--- a/nestly/scons.py
+++ b/nestly/scons.py
@@ -89,9 +89,8 @@ class SConsWrap(object):
         :param kw: Additional parameters to pass to
             :meth:`Nest.add() <nestly.core.Nest.add>`.
         """
-        if core._is_iter(nestable):
-            self.checkpoints[name] = self.nest
-            self.nest = copy.copy(self.nest)
+        self.checkpoints[name] = self.nest
+        self.nest = copy.copy(self.nest)
         return self.nest.add(name, nestable, **kw)
 
     def pop(self, name=None):


### PR DESCRIPTION
This resolves #23, but maybe we should put out a new release before closing the issue? Don't know that I have the creds for that.